### PR TITLE
prevent API call to break if no stories

### DIFF
--- a/app/controllers/api/v1/stories_controller.rb
+++ b/app/controllers/api/v1/stories_controller.rb
@@ -20,6 +20,8 @@ class Api::V1::StoriesController < Api::V1::BaseController
     end
   end
   def show
-    @story = Story.find_by_slug(params[:id])
+    unless @story = Story.find_by_slug(params[:id])
+      render json: { errors: "no story found with slug #{params[:id]}" }, status: 404
+    end
   end
 end

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -1,35 +1,32 @@
-if story
-  json.id story.id
-  json.slug story.slug
+json.id story.id
+json.slug story.slug
 
-  if story.company
-    json.company do
-      json.name story.company.name
-      json.url story.company.url
-      json.logo story.company.logo.url(:thumbnail)
-    end
+if story.company
+  json.company do
+    json.name story.company.name
+    json.url story.company.url
+    json.logo story.company.logo.url(:thumbnail)
   end
-  json.title do
-    json.fr story.title_fr
-    json.en story.title_en
-  end
-  json.summary do
-    json.fr story.summary_fr
-    json.en story.summary_en
-  end
-  json.description do
-    json.fr story.description_fr
-    json.en story.description_en
-  end
-  json.picture story.picture.url(:cover)
-
-  user = User.includes(:batch).find(story.user_id)
-
-  json.alumni do
-    json.extract!user , :id, :github_nickname, :thumbnail, :first_name, :last_name
-    json.slug user.batch.slug if user.batch
-    json.city user.batch.city.name if user.batch
-  end
-else
-  json.error "No story with that slug"
 end
+json.title do
+  json.fr story.title_fr
+  json.en story.title_en
+end
+json.summary do
+  json.fr story.summary_fr
+  json.en story.summary_en
+end
+json.description do
+  json.fr story.description_fr
+  json.en story.description_en
+end
+json.picture story.picture.url(:cover)
+
+user = User.includes(:batch).find(story.user_id)
+
+json.alumni do
+  json.extract!user , :id, :github_nickname, :thumbnail, :first_name, :last_name
+  json.slug user.batch.slug if user.batch
+  json.city user.batch.city.name if user.batch
+end
+

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -1,31 +1,35 @@
-json.id story.id
-json.slug story.slug
+if story
+  json.id story.id
+  json.slug story.slug
 
-if story.company
-  json.company do
-    json.name story.company.name
-    json.url story.company.url
-    json.logo story.company.logo.url(:thumbnail)
+  if story.company
+    json.company do
+      json.name story.company.name
+      json.url story.company.url
+      json.logo story.company.logo.url(:thumbnail)
+    end
   end
-end
-json.title do
-  json.fr story.title_fr
-  json.en story.title_en
-end
-json.summary do
-  json.fr story.summary_fr
-  json.en story.summary_en
-end
-json.description do
-  json.fr story.description_fr
-  json.en story.description_en
-end
-json.picture story.picture.url(:cover)
+  json.title do
+    json.fr story.title_fr
+    json.en story.title_en
+  end
+  json.summary do
+    json.fr story.summary_fr
+    json.en story.summary_en
+  end
+  json.description do
+    json.fr story.description_fr
+    json.en story.description_en
+  end
+  json.picture story.picture.url(:cover)
 
-user = User.includes(:batch).find(story.user_id)
+  user = User.includes(:batch).find(story.user_id)
 
-json.alumni do
-  json.extract!user , :id, :github_nickname, :thumbnail, :first_name, :last_name
-  json.slug user.batch.slug if user.batch
-  json.city user.batch.city.name if user.batch
+  json.alumni do
+    json.extract!user , :id, :github_nickname, :thumbnail, :first_name, :last_name
+    json.slug user.batch.slug if user.batch
+    json.city user.batch.city.name if user.batch
+  end
+else
+  json.error "No story with that slug"
 end


### PR DESCRIPTION
fixes #227 
Bug raises on an API call on `stories` with wrong slug to find it. If no `story` is found, `_story.json.jbuilder` can't be built. I put a condition on the builder and return a JSON with key 'error' if no `story` is found. @ssaunier please review 