### PR TITLE
Add link to onboarding

### DIFF
--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -30,13 +30,13 @@ class SlackController < ActionController::Base
         end
 
         {
-          text: "*#{user.name}* has been onboarded in *Batch ##{user.batch.slug} - #{user.batch.city.name}*",
+          "text": "*#{user.name}* has been onboarded in *Batch ##{user.batch.slug} - #{user.batch.city.name}*",
           "attachments": [
             {
-              color: "#60C275",
-              thumb_url: user.gravatar_url,
-              attachment_type: "default",
-              fields: [
+              "color": "#60C275",
+              "thumb_url": user.gravatar_url,
+              "attachment_type": "default",
+              "fields": [
                 {
                   "title": "School",
                   "value": user.school,
@@ -55,7 +55,7 @@ class SlackController < ActionController::Base
             },
             {
               "color": "#4484C2",
-              "text": "<http://kitt.lewagon.org/camps/#{user.batch.slug}/classmates|View #{user.batch.users.length} classmates>",
+              "text": "<http://kitt.lewagon.org/camps/#{user.batch.slug}/classmates|View #{user.batch.users.length} classmates>"
             }
           ]
         }

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -55,8 +55,7 @@ class SlackController < ActionController::Base
             },
             {
               "color": "#4484C2",
-              "title": "View XX classmates",
-              "title_link": "http://kitt.lewagon.org/camps/XX/classmates"
+              "text": "<http://kitt.lewagon.org/camps/#{user.batch.slug}/classmates|View #{user.batch.users.length} classmates>",
             }
           ]
         }

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -52,6 +52,11 @@ class SlackController < ActionController::Base
                   "value": user.private_bio
                 }
               ]
+            },
+            {
+              "color": "#4484C2",
+              "title": "View XX classmates",
+              "title_link": "http://kitt.lewagon.org/camps/XX/classmates"
             }
           ]
         }


### PR DESCRIPTION
Is there anything else that need to be done here?
This is what it produces:
<img width="630" alt="screen shot 2017-04-16 at 17 05 40" src="https://cloud.githubusercontent.com/assets/16181471/25072499/8c7bebd4-22c7-11e7-91f3-adfac5b9996d.png">
A little link at the bottom...

I can't test it much as I don't have any database locally but it's not very complex code and can test tomorrow with new batch :)